### PR TITLE
Fix: Keep installed theme on non selected tabs. #7

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,17 @@
-var ff_version = parseInt(window.navigator.userAgent.split('/').pop().split('.')[0], 10);
+var env = []
+var theme_before_envify = {}
+var ff_version = '';
+
+async function start() {
+  theme_before_envify = await browser.theme.getCurrent();
+  ff_version = parseInt(window.navigator.userAgent.split('/').pop().split('.')[0], 10);
+  console.log(theme_before_envify);
+  console.log(ff_version);
+  loadEnv()
+  setupListeners();
+}
+
+start();
 
 function loadEnv() {
 
@@ -22,20 +35,31 @@ function loadEnv() {
 
 }
 
-browser.storage.onChanged.addListener(loadEnv)
+function setupListeners() {
+  browser.storage.onChanged.addListener(loadEnv)
 
-browser.runtime.onInstalled.addListener(function(details) {
-	browser.storage.sync.get("environments")
-		.then(function(results) {
-			if (!("environments" in results)) {
-				browser.storage.sync.set({"environments": { "": ""} })
-				browser.runtime.openOptionsPage()
-			}
-		})
-})
+  browser.runtime.onInstalled.addListener(function(details) {
+    browser.storage.sync.get("environments")
+      .then(function(results) {
+        if (!("environments" in results)) {
+          browser.storage.sync.set({"environments": { "": ""} })
+          browser.runtime.openOptionsPage()
+        }
+      })
+  })
 
-var env = []
-loadEnv()
+  browser.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+    if (tab.active) {
+      setTabColor(tab)
+    }
+  })
+
+  browser.tabs.onActivated.addListener(function(activeInfo) {
+    browser.tabs.get(activeInfo.tabId).then(function(tab) {
+      setTabColor(tab)
+    })
+  })
+}
 
 function setTabColor(tab) {
 	var url = tab.url
@@ -45,7 +69,7 @@ function setTabColor(tab) {
 		browser.theme.update(tab.windowId, generateThemeFromColor(color))
 	}
 	else {
-		browser.theme.reset(tab.windowId)
+		browser.theme.update(tab.windowId, theme_before_envify)
 	}
 }
 
@@ -76,17 +100,3 @@ function generateThemeFromColor(color) {
 
   return theme;
 }
-
-browser.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-	if (tab.active) {
-		setTabColor(tab)
-	}
-})
-
-browser.tabs.onActivated.addListener(function(activeInfo) {
-	browser.tabs.get(activeInfo.tabId).then(function(tab) {
-		setTabColor(tab)
-	})
-})
-
-

--- a/background.js
+++ b/background.js
@@ -5,8 +5,6 @@ var ff_version = '';
 async function start() {
   theme_before_envify = await browser.theme.getCurrent();
   ff_version = parseInt(window.navigator.userAgent.split('/').pop().split('.')[0], 10);
-  console.log(theme_before_envify);
-  console.log(ff_version);
   loadEnv()
   setupListeners();
 }


### PR DESCRIPTION
Unfortunately the fix for `browser.theme.reset` which landed in ff74 isn't enough for this extension.
However `browser.theme.getCurrent()` now behaves correctly so we can save the theme on the extension startup and restore the saved theme instead of resetting it.

To change the theme, the extension needs to be disabled and enabled back.