### PR TITLE
Better: keep system setting for darkmode.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,10 +1,8 @@
 var env = []
 var theme_before_envify = {}
-var ff_version = '';
 
 async function start() {
   theme_before_envify = await browser.theme.getCurrent();
-  ff_version = parseInt(window.navigator.userAgent.split('/').pop().split('.')[0], 10);
   loadEnv()
   setupListeners();
 }
@@ -72,29 +70,16 @@ function setTabColor(tab) {
 }
 
 function generateThemeFromColor(color) {
-  // "theme_frame" // >= 70
-  // "frame": colorLuminance(color, -0.3), // >= 70
-  // "tab_background_ext": invertColor(color, true), // >= 70
 	var theme = {
-		"images": { },
+		"images": { 
+			"theme_frame": ""
+		},
 		"colors": {
-			"toolbar": color
+			"toolbar": color,
+			"frame": colorLuminance(color, -0.3),
+			"tab_background_text": invertColor(color, true)
 		}
 	};
-
-  var headerURL = "headerURL";
-  var accentcolor = "accentcolor";
-  var textcolor = "textcolor";
-
-  if (ff_version >= 70) {
-    headerURL = "theme_frame";
-    accentcolor = "frame";
-    textcolor = "tab_background_text";
-  }
-
-  theme["images"][headerURL] = "";
-  theme["colors"][accentcolor] = colorLuminance(color, -0.3);
-  theme["colors"][textcolor] = invertColor(color, true);
 
   return theme;
 }

--- a/background.js
+++ b/background.js
@@ -76,6 +76,9 @@ function generateThemeFromColor(color) {
 			"toolbar": color,
 			"frame": colorLuminance(color, -0.3),
 			"tab_background_text": invertColor(color, true)
+		},
+		"properties": {
+			"color_scheme": "system"
 		}
 	};
 

--- a/background.js
+++ b/background.js
@@ -1,8 +1,6 @@
 var env = []
-var theme_before_envify = {}
 
 async function start() {
-  theme_before_envify = await browser.theme.getCurrent();
   loadEnv()
   setupListeners();
 }
@@ -65,7 +63,7 @@ function setTabColor(tab) {
 		browser.theme.update(tab.windowId, generateThemeFromColor(color))
 	}
 	else {
-		browser.theme.update(tab.windowId, theme_before_envify)
+    browser.theme.reset(tab.windowId)
 	}
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
 
   "applications": {
     "gecko": {
-      "id": "{3e75b332-ab7e-4c05-a991-06763c89d47a}"
+      "id": "{3e75b332-ab7e-4c05-a991-06763c89d47a}",
+      "strict_min_version": "70.0"
     }
   },
 


### PR DESCRIPTION
Before:

Debugger darkmode setting was dependent on the theme color:

<img width="1723" height="1006" alt="image" src="https://github.com/user-attachments/assets/5815532e-3069-4d7c-bf93-d9322b51dde3" />

After:

Respect system setting

<img width="1726" height="1005" alt="image" src="https://github.com/user-attachments/assets/8b60a76e-7f89-465b-8a48-e7854a0333fe" />
